### PR TITLE
fix: Trigger CI/CD only once after a PR closes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/changelog.rst'
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/changelog.rst'
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
       - name: Code format
         run: ec -verbose
 
+      - name: Check version information
+        run: |
+          pip install -e .
+          ./scripts/versioning.py
+
   sonarcloud:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What is the goal of this PR?**
Improve project's CI/CD performance and fix likely bug to occur.

**What has been done to achieve the goal?**
Add rule to only run CI/CD on pushes to main branch if there are changes in `docs/changelog.rst` file. If there is no new version, latest changes will modify the file in a following commit; otherwise, CI will indicate that the file needs to be modified.

**How to test if the changes work?**
Check CI/CD logs.

