### PR TITLE
Handle docker compose and docker space compose

### DIFF
--- a/docker/base.sh
+++ b/docker/base.sh
@@ -1,0 +1,12 @@
+DOCKER_COMPOSE_BIN="docker-compose"
+DOCKER_COMPOSE_FROM_DOCKER="docker compose"
+DOCKER_COMPOSE=""
+
+if [ -x "$(command -v $DOCKER_COMPOSE_BIN)" ]; then
+  DOCKER_COMPOSE=$DOCKER_COMPOSE_BIN
+elif [ -x "$(command -v $DOCKER_COMPOSE_FROM_DOCKER)" ]; then
+  DOCKER_COMPOSE=$DOCKER_COMPOSE_FROM_DOCKER
+else
+  echo "Neither 'docker-compose' and 'docker compose' found. At least one of them are mandatory."
+  exit 1
+fi

--- a/docker/base.sh
+++ b/docker/base.sh
@@ -4,9 +4,6 @@ DOCKER_COMPOSE=""
 
 if [ -x "$(command -v $DOCKER_COMPOSE_BIN)" ]; then
   DOCKER_COMPOSE=$DOCKER_COMPOSE_BIN
-elif [ -x "$(command -v $DOCKER_COMPOSE_FROM_DOCKER)" ]; then
-  DOCKER_COMPOSE=$DOCKER_COMPOSE_FROM_DOCKER
 else
-  echo "Neither 'docker-compose' and 'docker compose' found. At least one of them are mandatory."
-  exit 1
+  DOCKER_COMPOSE=$DOCKER_COMPOSE_FROM_DOCKER
 fi

--- a/docker/base.sh
+++ b/docker/base.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 DOCKER_COMPOSE_BIN="docker-compose"
 DOCKER_COMPOSE_FROM_DOCKER="docker compose"
 DOCKER_COMPOSE=""

--- a/docker/down.sh
+++ b/docker/down.sh
@@ -2,8 +2,9 @@
 
 ROOT="$(dirname $( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P ))"
 $ROOT/docker/env.sh
+. $ROOT/docker/base.sh
 
-docker-compose \
+$DOCKER_COMPOSE \
 --file $ROOT/docker/docker-compose.yaml \
 --project-directory $ROOT \
 down --volumes --rmi 'all'

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,8 +2,9 @@
 
 ROOT="$(dirname $( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P ))"
 $ROOT/docker/env.sh
+. $ROOT/docker/base.sh
 
-docker-compose \
+$DOCKER_COMPOSE \
 --file $ROOT/docker/docker-compose.yaml \
 --project-directory $ROOT \
 run --rm cly $@


### PR DESCRIPTION
**What is the goal of this PR? | Qual é o objetivo deste PR?**

Solve this [issue](https://github.com/mateusoliveira43/cly/issues/77) `Issue with new Docker compose command`

Create a script that can decide which "docker compose" binary should be used.

The priority still on the `docker-compose` binary. If `docker-compose` doesn't exist, then, use `docker compose`

`base.sh` can be used for other things later, like define "default" values and load from the base.

**What has been done to achieve the goal? | O que foi feito para alcançar o objetivo?**

Check if `docker-compose` binary exists. If yes, use it, if not, fallback to `docker compose`

**How to test if the changes work? | Como testar se as alterações funcionam?**

- Edit `run.sh` and add another line like: `echo $DOCKER_COMPOSE` after line 6
- run `docker/run.sh`
- If you have `docker-compose`, the output from the line above will be the path of your `docker-compose`
- If you don't have `docker-compose`, the output from the line above will be `docker compose`
  - You can simulate that you don't have `docker-compose` changing the content of `DOCKER_COMPOSE_BIN` on `base.sh` line 3 and run `docker/run.sh` again
